### PR TITLE
Added some MultiSet functionality

### DIFF
--- a/src/main/java/com/jnape/palatable/shoki/api/MultiSet.java
+++ b/src/main/java/com/jnape/palatable/shoki/api/MultiSet.java
@@ -1,12 +1,17 @@
 package com.jnape.palatable.shoki.api;
 
 import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.semigroup.Semigroup;
 import com.jnape.palatable.shoki.api.Natural.NonZero;
 
 import static com.jnape.palatable.lambda.functions.Fn2.curried;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.GTE.gte;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
 import static com.jnape.palatable.lambda.functions.builtin.fn3.FoldLeft.foldLeft;
+import static com.jnape.palatable.lambda.monoid.builtin.And.and;
+import static com.jnape.palatable.lambda.semigroup.builtin.Max.max;
+import static com.jnape.palatable.lambda.semigroup.builtin.Min.min;
 import static com.jnape.palatable.shoki.api.Natural.one;
 
 /**
@@ -106,5 +111,138 @@ public interface MultiSet<A> extends Collection<Natural, Tuple2<A, NonZero>>, Ra
      */
     default MultiSet<A> addAll(MultiSet<A> other) {
         return foldLeft(curried(ms -> into(ms::add)), this, other);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * Amortized <code>O(1)</code>.
+     */
+    @Override
+    default boolean contains(A a) {
+        return contains(a, one());
+    }
+
+    /**
+     * Determine if some value <code>k</code> <code>a</code>s are elements of this {@link MultiSet}.
+     * Equivalent to <code>get(a) >= k</code>
+     *
+     * @param a the value
+     * @param k the amount of a
+     * @return true if there are k <code>a</code>s in this {@link MultiSet}; false otherwise
+     */
+    default boolean contains(A a, NonZero k) {
+        return gte(k, get(a));
+    }
+
+    /**
+     * The union of two {@link MultiSet MultiSets}
+     * <code>xs</code> and <code>ys</code> is the {@link MultiSet} of those elements present in either <code>xs</code>
+     * or <code>ys</code> with the occurrences of whichever one had more elements. This is equivalent to
+     * {@link MultiSet#merge} partially applied with {@link com.jnape.palatable.lambda.semigroup.builtin.Max#max}.
+     *
+     * @param other the {@link MultiSet} to union with this {@link MultiSet}
+     * @return the union {@link MultiSet}
+     * @see MultiSet#merge
+     */
+    default MultiSet<A> union(MultiSet<A> other) {
+        return merge(max(), other);
+    }
+
+    /**
+     * The <a href="https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement"
+     * target="_new">difference</a> (also known as "relative complement") of two {@link MultiSet MultiSets}
+     * <code>xs</code> and <code>ys</code> is the {@link MultiSet} of in <code>xs</code> with all elements of
+     * <code>ys</code> removed.
+     *
+     * @param other the {@link MultiSet} to subtract from this {@link MultiSet}
+     * @return the difference {@link MultiSet}
+     */
+    default MultiSet<A> difference(MultiSet<A> other) {
+        return foldLeft(curried(ms -> into(ms::remove)), this, other);
+    }
+
+    /**
+     * Determine if another {@link MultiSet} is a subset of this {@link MultiSet}. A {@link MultiSet} <code>x</code> is
+     * a subset of <code>y</code> if for every <code>a^i</code> in <code>x</code> there exists <code>a^j</code> in
+     * <code>y</code> where ^ denotes the number of occurrences in the multiset.
+     *
+     * @param other the {@link MultiSet} to test whether it's a subset
+     * @return whether other is a subset
+     */
+    default boolean inclusion(MultiSet<A> other) {
+        return and().foldMap(into(this::contains), other);
+    }
+
+    /**
+     * The union of two {@link MultiSet MultiSets}
+     * <code>xs</code> and <code>ys</code> is the {@link MultiSet} of those elements present in both <code>xs</code>
+     * and <code>ys</code> with the occurrences of whichever one had less elements. This is equivalent to
+     * {@link MultiSet#merge} partially applied with {@link com.jnape.palatable.lambda.semigroup.builtin.Min#min}.
+     *
+     * @param other the {@link MultiSet} to intersect with this {@link MultiSet}
+     * @return the union {@link MultiSet}
+     * @see MultiSet#merge
+     */
+    default MultiSet<A> intersection(MultiSet<A> other) {
+        return merge(min(), other);
+    }
+
+
+    /**
+     * The symmetric difference of two {@link MultiSet MultiSets} <code>xs</code> and <code>ys</code> is the
+     * {@link MultiSet} of the occurrence elements present in either <code>xs</code> or <code>ys</code> but not the
+     * other.
+     *
+     * @param other the {@link MultiSet} to symmetrically subtract from this {@link MultiSet}
+     * @return the union {@link MultiSet}
+     * @see MultiSet#merge
+     */
+    default MultiSet<A> symmetricDifference(MultiSet<A> other) {
+        return difference(other).union(other.difference(this));
+    }
+
+    /**
+     * {@link Set} containing the unique elements from the {@link MultiSet}
+     *
+     * @return the unique {@link Set}
+     */
+    Set<Natural, A> unique();
+
+    /**
+     * Combine {@link MultiSet}s with a {@link Semigroup} to handle the combining of the amounts.
+     * Note that if one of the {@link MultiSet}s does not contain an {@link A} it will still pass
+     * {@link com.jnape.palatable.shoki.api.Natural.Zero} to the {@link Semigroup}.
+     *
+     * @param semigroup the {@link Semigroup}
+     * @param other     the other {@link MultiSet}
+     * @return the merged {@link MultiSet}
+     */
+    default MultiSet<A> merge(Semigroup<Natural> semigroup, MultiSet<A> other) {
+        return foldLeft((acc, a) -> semigroup
+                                .apply(get(a), other.get(a)).match(constantly(acc), result -> acc.add(a, result)),
+                        this.difference(this), // Empty but the correct impl.
+                        unique().union(other.unique()));
+    }
+
+    /**
+     * Common {@link EquivalenceRelation}s between {@link MultiSet MultiSets}.
+     */
+    final class EquivalenceRelations {
+        private EquivalenceRelations() {
+        }
+
+        /**
+         * An {@link EquivalenceRelation} between two {@link MultiSet}s that holds if, and only if, both
+         * {@link MultiSet MultiSets} have the same elements. <code>O(n)</code>.
+         *
+         * @param <A> the element type
+         * @param <S> the {@link MultiSet} subtype of the arguments
+         * @return the {@link EquivalenceRelation}
+         */
+        public static <A, S extends MultiSet<A>> EquivalenceRelation<S> sameElements() {
+            EquivalenceRelation<S> sameMembership = (xs, ys) -> and().foldMap(into(ys::contains), xs);
+            return Sizable.EquivalenceRelations.<S>sameSizes().and(sameMembership);
+        }
     }
 }

--- a/src/main/java/com/jnape/palatable/shoki/impl/HashMultiSet.java
+++ b/src/main/java/com/jnape/palatable/shoki/impl/HashMultiSet.java
@@ -9,6 +9,7 @@ import com.jnape.palatable.shoki.api.HashingAlgorithm;
 import com.jnape.palatable.shoki.api.MultiSet;
 import com.jnape.palatable.shoki.api.Natural;
 import com.jnape.palatable.shoki.api.Natural.NonZero;
+import com.jnape.palatable.shoki.api.Set;
 import com.jnape.palatable.shoki.api.SizeInfo.Known;
 
 import java.util.Objects;
@@ -54,11 +55,21 @@ public final class HashMultiSet<A> implements MultiSet<A> {
 
     /**
      * {@inheritDoc}
+     * <code>O(n)</code>
+     */
+    @Override
+    public Set<Natural, A> unique() {
+        return multiplicityMap.keys();
+    }
+
+    /**
+     * {@inheritDoc}
      * Amortized <code>O(1)</code>.
      */
     @Override
     public HashMultiSet<A> add(A a, NonZero k) {
-        return new HashMultiSet<>(multiplicityMap.put(a, multiplicityMap.get(a).fmap(k::plus).orElse(k)));
+        return new HashMultiSet<>(multiplicityMap.put(a, multiplicityMap.get(a).fmap(k::plus).orElse(k))
+        );
     }
 
     /**
@@ -70,7 +81,8 @@ public final class HashMultiSet<A> implements MultiSet<A> {
         return multiplicityMap.get(a)
                 .fmap(n -> new HashMultiSet<>(n.minus(k).orElse(zero())
                                                       .match(zero -> multiplicityMap.remove(a),
-                                                             difference -> multiplicityMap.put(a, difference))))
+                                                             difference -> multiplicityMap.put(a, difference))
+                ))
                 .orElse(this);
     }
 
@@ -139,15 +151,6 @@ public final class HashMultiSet<A> implements MultiSet<A> {
 
     /**
      * {@inheritDoc}
-     * Amortized <code>O(1)</code>.
-     */
-    @Override
-    public boolean contains(A a) {
-        return multiplicityMap.contains(a);
-    }
-
-    /**
-     * {@inheritDoc}
      * <code>O(1)</code>.
      */
     @Override
@@ -200,7 +203,8 @@ public final class HashMultiSet<A> implements MultiSet<A> {
      */
     public static <A> HashMultiSet<A> empty(EquivalenceRelation<A> equivalenceRelation,
                                             HashingAlgorithm<A> hashingAlgorithm) {
-        return new HashMultiSet<>(HashMap.empty(equivalenceRelation, hashingAlgorithm));
+        return new HashMultiSet<>(HashMap.empty(equivalenceRelation, hashingAlgorithm)
+        );
     }
 
     /**

--- a/src/test/java/com/jnape/palatable/shoki/api/MultiSetTest.java
+++ b/src/test/java/com/jnape/palatable/shoki/api/MultiSetTest.java
@@ -83,10 +83,14 @@ public class MultiSetTest {
             assertEquals(one(), union.get("c"));
             assertEquals(known(abs(4)), union.sizeInfo());
 
-            assertThat(first.union(first), equivalentTo(first, MultiSet.EquivalenceRelations.sameElements()));
-            assertThat(first.union(empty()), equivalentTo(first, MultiSet.EquivalenceRelations.sameElements()));
-            assertThat(second.union(second), equivalentTo(second, MultiSet.EquivalenceRelations.sameElements()));
-            assertThat(second.union(empty()), equivalentTo(second, MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(first.union(first),
+                       equivalentTo(first, MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
+            assertThat(first.union(empty()),
+                       equivalentTo(first, MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
+            assertThat(second.union(second),
+                       equivalentTo(second, MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
+            assertThat(second.union(empty()),
+                       equivalentTo(second, MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
         }
 
         @Test
@@ -102,12 +106,14 @@ public class MultiSetTest {
             assertEquals(one(), union.get("c"));
             assertEquals(known(abs(3)), union.sizeInfo());
 
-            assertThat(first.intersection(first), equivalentTo(first, MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(first.intersection(first),
+                       equivalentTo(first, MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
             assertThat(first.intersection(empty()),
-                       equivalentTo(empty(), MultiSet.EquivalenceRelations.sameElements()));
-            assertThat(second.intersection(second), equivalentTo(second, MultiSet.EquivalenceRelations.sameElements()));
+                       equivalentTo(empty(), MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
+            assertThat(second.intersection(second),
+                       equivalentTo(second, MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
             assertThat(second.intersection(empty()),
-                       equivalentTo(empty(), MultiSet.EquivalenceRelations.sameElements()));
+                       equivalentTo(empty(), MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
         }
 
         @Test
@@ -133,13 +139,16 @@ public class MultiSetTest {
         public void symmetricDifference() {
             assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "b", "c"))
                                .symmetricDifference(HashMultiSet.of("b")),
-                       equivalentTo(HashMultiSet.of("a", "c"), MultiSet.EquivalenceRelations.sameElements()));
+                       equivalentTo(HashMultiSet.of("a", "c"),
+                                    MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
             assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "a", "a"))
                                .symmetricDifference(HashMultiSet.of("a")),
-                       equivalentTo(HashMultiSet.of("a", "a"), MultiSet.EquivalenceRelations.sameElements()));
+                       equivalentTo(HashMultiSet.of("a", "a"),
+                                    MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
             assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a"))
                                .symmetricDifference(HashMultiSet.of("a")),
-                       equivalentTo(HashMultiSet.empty(), MultiSet.EquivalenceRelations.sameElements()));
+                       equivalentTo(HashMultiSet.empty(),
+                                    MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
         }
     }
 
@@ -148,11 +157,14 @@ public class MultiSetTest {
         @Test
         public void sameElements() {
             assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.empty()),
-                       equivalentTo(HashMultiSet.empty(), MultiSet.EquivalenceRelations.sameElements()));
+                       equivalentTo(HashMultiSet.empty(),
+                                    MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
             assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a")),
-                       equivalentTo(HashMultiSet.of("a"), MultiSet.EquivalenceRelations.sameElements()));
+                       equivalentTo(HashMultiSet.of("a"),
+                                    MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
             assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "a")),
-                       not(equivalentTo(HashMultiSet.of("a"), MultiSet.EquivalenceRelations.sameElements())));
+                       not(equivalentTo(HashMultiSet.of("a"),
+                                        MultiSet.EquivalenceRelations.sameElementsSameMultiplicity())));
             assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of(cmpEqBy(String::length)::apply,
                                                                        fn1(String::length)
                                                                                .fmap(integer -> Integer
@@ -160,7 +172,7 @@ public class MultiSetTest {
                                                                                                integer))::apply,
                                                                        "a", "a")),
                        equivalentTo(HashMultiSet.of("b", "b"),
-                                    MultiSet.EquivalenceRelations.sameElements()));
+                                    MultiSet.EquivalenceRelations.sameElementsSameMultiplicity()));
         }
     }
 

--- a/src/test/java/com/jnape/palatable/shoki/api/MultiSetTest.java
+++ b/src/test/java/com/jnape/palatable/shoki/api/MultiSetTest.java
@@ -3,47 +3,165 @@ package com.jnape.palatable.shoki.api;
 import com.jnape.palatable.shoki.impl.HashMultiSet;
 import com.jnape.palatable.shoki.testsupport.DefaultMethodsMultiSet;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
+import static com.jnape.palatable.lambda.functions.Fn1.fn1;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.CmpEqBy.cmpEqBy;
 import static com.jnape.palatable.shoki.api.Natural.abs;
 import static com.jnape.palatable.shoki.api.Natural.one;
 import static com.jnape.palatable.shoki.api.Natural.zero;
 import static com.jnape.palatable.shoki.api.SizeInfo.known;
+import static com.jnape.palatable.shoki.impl.HashMultiSet.empty;
+import static com.jnape.palatable.shoki.testsupport.EquivalenceRelationMatcher.equivalentTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Enclosed.class)
 public class MultiSetTest {
+    public static final class DefaultMethods {
+        @Test
+        public void removeAll() {
+            assertTrue(DefaultMethodsMultiSet.<String>delegate(empty()).removeAll("foo").isEmpty());
+            assertEquals(zero(),
+                         DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "bar", "foo")).removeAll("foo")
+                                 .get("foo"));
+            assertEquals(known(one()),
+                         DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "bar", "foo")).removeAll("foo")
+                                 .sizeInfo());
+        }
 
-    @Test
-    public void removeAll() {
-        assertTrue(DefaultMethodsMultiSet.<String>delegate(HashMultiSet.empty()).removeAll("foo").isEmpty());
-        assertEquals(zero(),
-                     DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "bar", "foo")).removeAll("foo").get("foo"));
-        assertEquals(known(one()),
-                     DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "bar", "foo")).removeAll("foo").sizeInfo());
+        @Test
+        public void removeOne() {
+            assertTrue(DefaultMethodsMultiSet.<String>delegate(empty()).remove("foo").isEmpty());
+            assertEquals(one(),
+                         DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "foo")).remove("foo").get("foo"));
+            assertEquals(known(abs(2)),
+                         DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "bar", "foo")).remove("foo")
+                                 .sizeInfo());
+        }
+
+        @Test
+        public void addOne() {
+            assertEquals(one(), DefaultMethodsMultiSet.delegate(HashMultiSet.<String>empty()).add("foo").get("foo"));
+        }
+
+        @Test
+        public void addAll() {
+            assertTrue(DefaultMethodsMultiSet.<String>delegate(empty())
+                               .addAll(empty()).isEmpty());
+
+            MultiSet<String> addAll = DefaultMethodsMultiSet.<String>delegate(empty())
+                    .addAll(HashMultiSet.of("foo", "foo", "bar"));
+            assertEquals(abs(2), addAll.get("foo"));
+            assertEquals(abs(1), addAll.get("bar"));
+            assertEquals(known(abs(3)), addAll.sizeInfo());
+        }
+
+        @Test
+        public void merge() {
+            MultiSet<String> merge = DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "b"))
+                    .merge(Natural::plus, DefaultMethodsMultiSet.delegate(HashMultiSet.of("b", "c")));
+            assertEquals(one(), merge.get("a"));
+            assertEquals(abs(2), merge.get("b"));
+            assertEquals(one(), merge.get("c"));
+            assertEquals(known(abs(4)), merge.sizeInfo());
+        }
+
+        @Test
+        public void union() {
+            DefaultMethodsMultiSet<String> first  = DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "a", "b"));
+            DefaultMethodsMultiSet<String> second = DefaultMethodsMultiSet.delegate(HashMultiSet.of("b", "c"));
+            MultiSet<String> union = first
+                    .union(second);
+
+            assertEquals(abs(2), union.get("a"));
+            assertEquals(one(), union.get("b"));
+            assertEquals(one(), union.get("c"));
+            assertEquals(known(abs(4)), union.sizeInfo());
+
+            assertThat(first.union(first), equivalentTo(first, MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(first.union(empty()), equivalentTo(first, MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(second.union(second), equivalentTo(second, MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(second.union(empty()), equivalentTo(second, MultiSet.EquivalenceRelations.sameElements()));
+        }
+
+        @Test
+        public void intersection() {
+            DefaultMethodsMultiSet<String> first = DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "b", "b", "c"));
+            DefaultMethodsMultiSet<String> second = DefaultMethodsMultiSet
+                    .delegate(HashMultiSet.of("b", "b", "c", "c"));
+            MultiSet<String> union = first
+                    .intersection(second);
+
+            assertEquals(zero(), union.get("a"));
+            assertEquals(abs(2), union.get("b"));
+            assertEquals(one(), union.get("c"));
+            assertEquals(known(abs(3)), union.sizeInfo());
+
+            assertThat(first.intersection(first), equivalentTo(first, MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(first.intersection(empty()),
+                       equivalentTo(empty(), MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(second.intersection(second), equivalentTo(second, MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(second.intersection(empty()),
+                       equivalentTo(empty(), MultiSet.EquivalenceRelations.sameElements()));
+        }
+
+        @Test
+        public void inclusion() {
+            assertTrue(DefaultMethodsMultiSet.delegate(HashMultiSet.empty()).inclusion(HashMultiSet.empty()));
+            assertTrue(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a")).inclusion(HashMultiSet.empty()));
+            assertTrue(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a")).inclusion(HashMultiSet.of("a")));
+            assertTrue(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "a")).inclusion(HashMultiSet.of("a", "a")));
+            assertTrue(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "b")).inclusion(HashMultiSet.of("a")));
+            assertTrue(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "b")).inclusion(HashMultiSet.of("a", "b")));
+
+            assertFalse(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a")).inclusion(HashMultiSet.of("a", "a")));
+            assertFalse(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a")).inclusion(HashMultiSet.of("b")));
+        }
+
+        @Test
+        public void contains() {
+            assertTrue(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a")).contains("a"));
+            assertFalse(DefaultMethodsMultiSet.delegate(HashMultiSet.empty()).contains("a"));
+        }
+
+        @Test
+        public void symmetricDifference() {
+            assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "b", "c"))
+                               .symmetricDifference(HashMultiSet.of("b")),
+                       equivalentTo(HashMultiSet.of("a", "c"), MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "a", "a"))
+                               .symmetricDifference(HashMultiSet.of("a")),
+                       equivalentTo(HashMultiSet.of("a", "a"), MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a"))
+                               .symmetricDifference(HashMultiSet.of("a")),
+                       equivalentTo(HashMultiSet.empty(), MultiSet.EquivalenceRelations.sameElements()));
+        }
     }
 
-    @Test
-    public void removeOne() {
-        assertTrue(DefaultMethodsMultiSet.<String>delegate(HashMultiSet.empty()).remove("foo").isEmpty());
-        assertEquals(one(), DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "foo")).remove("foo").get("foo"));
-        assertEquals(known(abs(2)),
-                     DefaultMethodsMultiSet.delegate(HashMultiSet.of("foo", "bar", "foo")).remove("foo").sizeInfo());
+    public static final class EquivalenceRelations {
+
+        @Test
+        public void sameElements() {
+            assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.empty()),
+                       equivalentTo(HashMultiSet.empty(), MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a")),
+                       equivalentTo(HashMultiSet.of("a"), MultiSet.EquivalenceRelations.sameElements()));
+            assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of("a", "a")),
+                       not(equivalentTo(HashMultiSet.of("a"), MultiSet.EquivalenceRelations.sameElements())));
+            assertThat(DefaultMethodsMultiSet.delegate(HashMultiSet.of(cmpEqBy(String::length)::apply,
+                                                                       fn1(String::length)
+                                                                               .fmap(integer -> Integer
+                                                                                       .hashCode(
+                                                                                               integer))::apply,
+                                                                       "a", "a")),
+                       equivalentTo(HashMultiSet.of("b", "b"),
+                                    MultiSet.EquivalenceRelations.sameElements()));
+        }
     }
 
-    @Test
-    public void addOne() {
-        assertEquals(one(), DefaultMethodsMultiSet.delegate(HashMultiSet.<String>empty()).add("foo").get("foo"));
-    }
-
-    @Test
-    public void addAll() {
-        assertTrue(DefaultMethodsMultiSet.<String>delegate(HashMultiSet.empty())
-                           .addAll(HashMultiSet.empty()).isEmpty());
-
-        MultiSet<String> addAll = DefaultMethodsMultiSet.<String>delegate(HashMultiSet.empty())
-                .addAll(HashMultiSet.of("foo", "foo", "bar"));
-        assertEquals(abs(2), addAll.get("foo"));
-        assertEquals(abs(1), addAll.get("bar"));
-        assertEquals(known(abs(3)), addAll.sizeInfo());
-    }
 }

--- a/src/test/java/com/jnape/palatable/shoki/testsupport/DefaultMethodsMultiSet.java
+++ b/src/test/java/com/jnape/palatable/shoki/testsupport/DefaultMethodsMultiSet.java
@@ -4,6 +4,7 @@ import com.jnape.palatable.lambda.adt.Maybe;
 import com.jnape.palatable.lambda.adt.hlist.Tuple2;
 import com.jnape.palatable.shoki.api.MultiSet;
 import com.jnape.palatable.shoki.api.Natural;
+import com.jnape.palatable.shoki.api.Set;
 import com.jnape.palatable.shoki.api.SizeInfo;
 
 /**
@@ -66,6 +67,14 @@ public final class DefaultMethodsMultiSet<A> implements MultiSet<A> {
     @Override
     public boolean contains(A a) {
         return delegate.contains(a);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<Natural, A> unique() {
+        return delegate.unique();
     }
 
     /**


### PR DESCRIPTION
Default Methods:
- MultiSet#contains plus overload for amount
- MultiSet#union
- MultiSet#difference
- MultiSet#inclusion
- MultiSet#intersection
- MultiSet#symmetricDifference
- MultiSet#merge
- MultiSet.EquivalenceRelations#sameElements

Abstract Methods:
- MultiSet#unique

I feel pretty gross about some of the current Javadocs but I thought it would be easier to discuss over PR.