### PR TITLE
Upgrading gauntlet to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>dev.marksman</groupId>
             <artifactId>gauntlet</artifactId>
-            <version>0.3.1</version>
+            <version>0.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/jnape/palatable/shoki/impl/MultiSetTests.java
+++ b/src/test/java/com/jnape/palatable/shoki/impl/MultiSetTests.java
@@ -70,10 +70,10 @@ public class MultiSetTests extends GauntletApiBase {
 
         Prop<MultiSet<A>> union = predicate("xs.union(xs) == xs", xs -> xs.union(xs).equals(xs));
 
-        assertThat(all(elements).satisfy(allOf(isEmpty, contains, incDec)));
-        assertThat(all(elements, positiveNaturals(atLeastOne(100))).satisfy(allOf(incTimes, incCount, remove)));
-        assertThat(all(elements.hashSet()).satisfy(unique));
-        assertThat(all(multiSets(multiSet, elements)).satisfy(allOf(difference, union)));
+        checkThat(all(elements).satisfy(allOf(isEmpty, contains, incDec)));
+        checkThat(all(elements, positiveNaturals(atLeastOne(100))).satisfy(allOf(incTimes, incCount, remove)));
+        checkThat(all(elements.hashSet()).satisfy(unique));
+        checkThat(all(multiSets(multiSet, elements)).satisfy(allOf(difference, union)));
     }
 
     public static Natural fromBits(long bits, long... more) {


### PR DESCRIPTION
Just bumped the gauntlet version to 0.4.0.  The `assertThat` methods have been renamed to `checkThat` to avoid conflict with Hamcrest.